### PR TITLE
configure: auto-discover Homebrew SDL3 on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,23 @@ darwin*)
 	fi
 	AC_MSG_RESULT([*** DARWIN, building native Darwin version (SDL)])
 	PPC_CCASFLAGS="-DPREFIX=_"
+
+	dnl On macOS, Homebrew installs pkg-config metadata under its prefix
+	dnl (e.g. /opt/homebrew on Apple Silicon, /usr/local on Intel). Help
+	dnl PKG_CHECK_MODULES find sdl3.pc by adding those directories to
+	dnl PKG_CONFIG_PATH when they are not already searched.
+	AC_CHECK_PROG([BREW], [brew], [brew])
+	if test "x$BREW" != "x"; then
+		brew_prefix=`$BREW --prefix 2>/dev/null`
+		if test "x$brew_prefix" != "x"; then
+			PKG_CONFIG_PATH="$brew_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
+		fi
+		brew_sdl3=`$BREW --prefix sdl3 2>/dev/null`
+		if test "x$brew_sdl3" != "x"; then
+			PKG_CONFIG_PATH="$brew_sdl3/lib/pkgconfig:$PKG_CONFIG_PATH"
+		fi
+		export PKG_CONFIG_PATH
+	fi
 ;;
 beos*)
 	OSAPI_DIR=beos


### PR DESCRIPTION
## Problem

`./configure` locates SDL3 via `pkg-config` (`PKG_CHECK_MODULES([SDL3], [sdl3 >= 3.0.0])`). A `pkg-config` that does not search the Homebrew prefix (e.g. a non-Homebrew one from the system or MacPorts) fails to find `sdl3.pc` even when SDL3 is installed via `brew install sdl3`, producing:

```
checking for sdl3 >= 3.0.0... no
configure: error: *** SDL3 >= 3.0.0 not found! Install SDL3 development libraries.
```

Reported in #38 (MacBook Pro M1, macOS 12.7.6, SDL3 at `/opt/homebrew/opt/sdl3`).

## Fix

On Darwin, detect `brew` and prepend `$(brew --prefix)/lib/pkgconfig` and the `sdl3` keg's pkgconfig dir to `PKG_CONFIG_PATH` before the SDL3 check. This makes `configure` find SDL3 out of the box, even with an empty `PKG_CONFIG_PATH`.

## Testing

Regenerated `configure` with `autoreconf -i`, then ran `./configure --enable-ui=sdl` with `PKG_CONFIG_PATH=""` to simulate the broken environment:

```
checking for brew... brew
checking for sdl3 >= 3.0.0... yes
final linker add: -L/opt/homebrew/lib -Wl,-rpath,/opt/homebrew/lib -lSDL3
```

Previously this failed; now it auto-discovers SDL3.

Fixes #38
