### PR TITLE
Build fixes and a non-PIE requirement fix for the x86_64 JIT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ jitc_trace.log
 
 # Autotools generated
 aclocal.m4
+compile
 config.guess
 config.h.in
 config.sub

--- a/compile
+++ b/compile
@@ -1,1 +1,0 @@
-/opt/homebrew/Cellar/automake/1.18.1/share/automake-1.18/compile

--- a/configure.ac
+++ b/configure.ac
@@ -236,6 +236,61 @@ AC_PROG_CXX
 AC_PROG_CPP
 AM_PROG_AS
 
+dnl The x86_64 JIT backend has two distinct address requirements:
+dnl
+dnl   - it embeds absolute 32-bit addresses of the CPU state into generated
+dnl     code, so the CPU state allocation must sit below 4GB;
+dnl   - it reaches native helper routines with call rel32, whose signed 32-bit
+dnl     displacement means those helpers must be within +-2GB of the
+dnl     translation cache.
+dnl
+dnl Both used to be satisfied by the default non-PIE link.  Toolchains
+dnl defaulting to PIE (Arch, Fedora, Ubuntu, ...) load the executable around
+dnl 0x5555xxxxxxxx instead, which also pushes the heap up there; the
+dnl displacements silently truncate and the emulator jumps into hyperspace on
+dnl the first translated instruction.
+dnl
+dnl This does not apply to cpu_jitc_x86: in a 32-bit process every address
+dnl already fits in 32 bits and call rel32 reaches the whole address space, so
+dnl PIE is harmless there and worth keeping for ASLR.
+dnl
+dnl Only the link mode matters: PIC/PIE objects work fine in a non-PIE
+dnl executable, so -fno-pie is deliberately NOT added -- putting it in CFLAGS
+dnl would break later configure link tests, which are still linked as PIE.
+dnl
+dnl The probes below describe the toolchain's defaults, not the final binary,
+dnl so the runtime checks in ppc_cpu_init()/asmCALL() remain the real guard.
+case "$CPU_DIR" in
+cpu_jitc_x86_64)
+	AC_MSG_CHECKING([whether $CC defaults to PIE])
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#ifndef __PIE__
+#error not pie
+#endif
+	]])], [ppc_cc_pie=yes], [ppc_cc_pie=no])
+	AC_MSG_RESULT([$ppc_cc_pie])
+
+	AC_MSG_CHECKING([whether the linker accepts -no-pie])
+	ac_save_LDFLAGS="$LDFLAGS"
+	LDFLAGS="$LDFLAGS -no-pie"
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+		[ppc_ld_nopie=yes], [ppc_ld_nopie=no])
+	LDFLAGS="$ac_save_LDFLAGS"
+	AC_MSG_RESULT([$ppc_ld_nopie])
+
+	if test "x$ppc_ld_nopie" = xyes; then
+		PPC_LDFLAGS="$PPC_LDFLAGS -no-pie"
+	elif test "x$ppc_cc_pie" = xyes; then
+		dnl PIE by default and no way to turn it off: the resulting binary
+		dnl would load above 4GB and crash on the first translated
+		dnl instruction.  Refuse rather than ship a known-broken build.
+		AC_MSG_ERROR([*** $CPU_DIR requires a non-PIE executable, but $CC
+defaults to PIE and the linker does not accept -no-pie. Rebuild with a
+toolchain supporting -no-pie, or configure with --enable-cpu=generic. ***])
+	fi
+;;
+esac
+
 dnl To ensure backward compatibility, Automake's `AM_PROG_LEX' invokes
 dnl (indirectly) this macro twice, which will cause an annoying but
 dnl benign "`AC_PROG_LEX' invoked multiple times" warning.  Future

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ VERSION=0.6pre
 AC_INIT(PACKAGE, VERSION)
 
 dnl Check the system.
-AC_CANONICAL_SYSTEM
+AC_CANONICAL_TARGET
 
 AC_SUBST(PACKAGE)
 AC_SUBST(VERSION)
@@ -67,7 +67,7 @@ fi
 AC_CONFIG_SRCDIR([src/system/types.h])
 AM_INIT_AUTOMAKE(no-define)
 
-AC_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 dnl Check OS specifica
 
@@ -242,7 +242,7 @@ dnl benign "`AC_PROG_LEX' invoked multiple times" warning.  Future
 dnl versions of Automake will fix this issue; meanwhile, just ignore
 dnl this message.
 dnl --- GNU Autoconf (version 2.58, 18 March 2004)
-AM_PROG_LEX
+AM_PROG_LEX([noyywrap])
 
 AC_PROG_YACC
 AC_PATH_PROG(AR, ar)
@@ -336,21 +336,21 @@ qt)
 
 	dnl Checks for Qt library.
 	AC_CACHE_CHECK([for Qt library],
-	  ac_qtlib, [
+	  ac_cv_qtlib, [
 	  for X in qt-mt qt; do
-	    if test -z "$ac_qtlib"; then
+	    if test -z "$ac_cv_qtlib"; then
 	      if test -f $QTDIR/lib/lib$X.so -o -f $QTDIR/lib/lib$X.a; then
-	        ac_qtlib=$X
+	        ac_cv_qtlib=$X
 	      fi
 	    fi
 	  done
 	])
-	if test -z "$ac_qtlib"; then
+	if test -z "$ac_cv_qtlib"; then
 	  AC_MSG_ERROR([Qt library not found. Maybe QTDIR isn't properly set.])
 	fi
 
 	dnl Check for Qt multi-thread support.
-	if test "x$ac_qtlib" = "xqt-mt"; then
+	if test "x$ac_cv_qtlib" = "xqt-mt"; then
 	  ac_thread="thread"
 	fi
 	AC_SUBST(ac_thread)
@@ -359,20 +359,20 @@ qt)
 	LIBS="-L$QTDIR/lib -L/usr/X11R6/lib"
 
 	AC_CACHE_CHECK(
-		[for Qt library version >= 3.0.0], ac_qtlib_version,
-		[	AC_TRY_LINK(
-			[
+		[for Qt library version >= 3.0.0], ac_cv_qtlib_version,
+		[	AC_LINK_IFELSE([AC_LANG_PROGRAM(
+			[[
 				#include "qglobal.h"
-			],
-			[
+			]],
+			[[
 				#if QT_VERSION < 0x030000
 				#error Qt library 3.0.0 or greater required.
 				#endif
-			],
+			]])],
 			[
-				ac_qtlib_version="yes"
+				ac_cv_qtlib_version="yes"
 				QT_CFLAGS="$CFLAGS"
-				QT_LIBS="-l$ac_qtlib"
+				QT_LIBS="-l$ac_cv_qtlib"
 				QT_LDFLAGS="$LIBS"
 			],
 			[
@@ -427,19 +427,18 @@ dnl Checks for some functions.
 AC_CHECK_FUNCS([gettimeofday memset setenv])
 
 AC_CHECK_FUNCS(log2, , AC_MSG_CHECKING(for log2 in math.h)
-	AC_TRY_LINK([#include <math.h>], 
-	[ log2(1.0); ], 
-	AC_DEFINE(HAVE_LOG2) AC_MSG_RESULT(yes),
-	AC_MSG_RESULT(no)))
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]],
+	[[ log2(1.0); ]])],
+	[AC_DEFINE(HAVE_LOG2) AC_MSG_RESULT(yes)],
+	[AC_MSG_RESULT(no)]))
 
 AC_CHECK_FUNCS(exp2, , AC_MSG_CHECKING(for exp2 in math.h)
-	AC_TRY_LINK([#include <math.h>], 
-	[ exp2(0.0); ], 
-	AC_DEFINE(HAVE_EXP2) AC_MSG_RESULT(yes),
-	AC_MSG_RESULT(no)))
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <math.h>]],
+	[[ exp2(0.0); ]])],
+	[AC_DEFINE(HAVE_EXP2) AC_MSG_RESULT(yes)],
+	[AC_MSG_RESULT(no)]))
 
 dnl Checks for header files.
-AC_HEADER_STDC
 AC_CHECK_HEADERS(pthread.h, AC_DEFINE(PTHREAD_HDR, <pthread.h>, [Have pthread.h?]))
 AC_CHECK_HEADERS([sys/socket.h])
 AC_CHECK_HEADERS([asm/types.h])
@@ -504,7 +503,7 @@ AC_CHECK_SIZEOF(long long, 8)
 
 #AC_SUBST(PTHREAD_FLAGS)
 
-AC_OUTPUT([
+AC_CONFIG_FILES([
 Makefile
 doc/Makefile
 scripts/Makefile
@@ -549,6 +548,7 @@ src/system/ui/win32/Makefile
 src/system/ui/x11/Makefile
 src/tools/Makefile
 ])
+AC_OUTPUT
 
 AC_MSG_RESULT([])
 AC_MSG_RESULT([$0 successful.])

--- a/configure.ac
+++ b/configure.ac
@@ -236,19 +236,18 @@ AC_PROG_CXX
 AC_PROG_CPP
 AM_PROG_AS
 
-dnl The x86_64 JIT backend has two distinct address requirements:
+dnl On Linux, the x86_64 JIT maps its translation cache below 2GB with
+dnl MAP_32BIT.  Generated code reaches native helper routines in the executable
+dnl with call rel32, whose signed 32-bit displacement requires those helpers to
+dnl be within +-2GB of the translation cache.  A non-PIE executable loads low
+dnl enough to satisfy that requirement, while toolchains defaulting to PIE
+dnl (Arch, Fedora, Ubuntu, ...) load it around 0x5555xxxxxxxx; the displacement
+dnl then exceeds rel32's range and used to be silently truncated.
 dnl
-dnl   - it embeds absolute 32-bit addresses of the CPU state into generated
-dnl     code, so the CPU state allocation must sit below 4GB;
-dnl   - it reaches native helper routines with call rel32, whose signed 32-bit
-dnl     displacement means those helpers must be within +-2GB of the
-dnl     translation cache.
-dnl
-dnl Both used to be satisfied by the default non-PIE link.  Toolchains
-dnl defaulting to PIE (Arch, Fedora, Ubuntu, ...) load the executable around
-dnl 0x5555xxxxxxxx instead, which also pushes the heap up there; the
-dnl displacements silently truncate and the emulator jumps into hyperspace on
-dnl the first translated instruction.
+dnl This configure workaround restores the required Linux layout.  On systems
+dnl without MAP_32BIT, including macOS where it is defined to zero, mmap may
+dnl place the translation cache anywhere; asmCALL() therefore remains the
+dnl platform-independent runtime guard for the rel32 requirement.
 dnl
 dnl This does not apply to cpu_jitc_x86: in a 32-bit process every address
 dnl already fits in 32 bits and call rel32 reaches the whole address space, so
@@ -258,17 +257,18 @@ dnl Only the link mode matters: PIC/PIE objects work fine in a non-PIE
 dnl executable, so -fno-pie is deliberately NOT added -- putting it in CFLAGS
 dnl would break later configure link tests, which are still linked as PIE.
 dnl
-dnl The probes below describe the toolchain's defaults, not the final binary,
-dnl so the runtime checks in ppc_cpu_init()/asmCALL() remain the real guard.
+dnl The probes below describe the toolchain's defaults, not the final binary.
 case "$CPU_DIR" in
 cpu_jitc_x86_64)
-	AC_MSG_CHECKING([whether $CC defaults to PIE])
+	AC_LANG_PUSH([C++])
+
+	AC_MSG_CHECKING([whether $CXX defaults to PIE])
 	AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #ifndef __PIE__
 #error not pie
 #endif
-	]])], [ppc_cc_pie=yes], [ppc_cc_pie=no])
-	AC_MSG_RESULT([$ppc_cc_pie])
+	]])], [ppc_cxx_pie=yes], [ppc_cxx_pie=no])
+	AC_MSG_RESULT([$ppc_cxx_pie])
 
 	AC_MSG_CHECKING([whether the linker accepts -no-pie])
 	ac_save_LDFLAGS="$LDFLAGS"
@@ -280,14 +280,16 @@ cpu_jitc_x86_64)
 
 	if test "x$ppc_ld_nopie" = xyes; then
 		PPC_LDFLAGS="$PPC_LDFLAGS -no-pie"
-	elif test "x$ppc_cc_pie" = xyes; then
-		dnl PIE by default and no way to turn it off: the resulting binary
-		dnl would load above 4GB and crash on the first translated
-		dnl instruction.  Refuse rather than ship a known-broken build.
-		AC_MSG_ERROR([*** $CPU_DIR requires a non-PIE executable, but $CC
+	elif test "x$ppc_cxx_pie" = xyes; then
+		dnl PIE by default and no way to turn it off: on Linux the native
+		dnl helpers would be outside rel32 range of the MAP_32BIT
+		dnl translation cache.  Refuse rather than ship a known-broken build.
+		AC_MSG_ERROR([*** $CPU_DIR requires a non-PIE executable, but $CXX
 defaults to PIE and the linker does not accept -no-pie. Rebuild with a
 toolchain supporting -no-pie, or configure with --enable-cpu=generic. ***])
 	fi
+
+	AC_LANG_POP([C++])
 ;;
 esac
 

--- a/src/cpu/cpu_jitc_x86_64/ppc_cpu.cc
+++ b/src/cpu/cpu_jitc_x86_64/ppc_cpu.cc
@@ -23,6 +23,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cstdint>
 #include <unistd.h>
 
 #include "debug/tracers.h"
@@ -266,6 +267,18 @@ JITC *gJITC;
 bool ppc_cpu_init()
 {
 	gCPU = ppc_malloc(sizeof *gCPU);
+	// The JIT encodes the address of the CPU state as a 32-bit absolute
+	// value in generated code, so the whole struct must live in the low 4GB.
+	// A non-PIE executable gets a low heap and satisfies this; a PIE one
+	// does not. Written to avoid overflowing when the allocation sits near
+	// the top of the address space.
+	if (uintptr_t(gCPU) > 0xffffffffULL - (sizeof *gCPU - 1)) {
+		PPC_CPU_ERR("CPU state allocated at %p, which does not fit in the "
+			"low 4GB. The x86_64 JIT encodes its address as a 32-bit "
+			"absolute value, so the allocation must sit below 4GB; linking "
+			"the executable non-PIE (-no-pie) is the usual way to get a "
+			"low heap.\n", gCPU);
+	}
 	memset(gCPU, 0, sizeof *gCPU);
 	gCPU->pvr = gConfig->getConfigUInt(CPU_KEY_PVR);
 

--- a/src/cpu/cpu_jitc_x86_64/ppc_cpu.cc
+++ b/src/cpu/cpu_jitc_x86_64/ppc_cpu.cc
@@ -23,7 +23,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cstdint>
 #include <unistd.h>
 
 #include "debug/tracers.h"
@@ -267,18 +266,6 @@ JITC *gJITC;
 bool ppc_cpu_init()
 {
 	gCPU = ppc_malloc(sizeof *gCPU);
-	// The JIT encodes the address of the CPU state as a 32-bit absolute
-	// value in generated code, so the whole struct must live in the low 4GB.
-	// A non-PIE executable gets a low heap and satisfies this; a PIE one
-	// does not. Written to avoid overflowing when the allocation sits near
-	// the top of the address space.
-	if (uintptr_t(gCPU) > 0xffffffffULL - (sizeof *gCPU - 1)) {
-		PPC_CPU_ERR("CPU state allocated at %p, which does not fit in the "
-			"low 4GB. The x86_64 JIT encodes its address as a 32-bit "
-			"absolute value, so the allocation must sit below 4GB; linking "
-			"the executable non-PIE (-no-pie) is the usual way to get a "
-			"low heap.\n", gCPU);
-	}
 	memset(gCPU, 0, sizeof *gCPU);
 	gCPU->pvr = gConfig->getConfigUInt(CPU_KEY_PVR);
 

--- a/src/cpu/cpu_jitc_x86_64/x86_64asm.cc
+++ b/src/cpu/cpu_jitc_x86_64/x86_64asm.cc
@@ -20,9 +20,11 @@
 
 #include <cstring>
 #include <cstdlib>
+#include <cstdint>
 
 #include "tools/debug.h"
 #include "tools/snprintf.h"
+#include "debug/tracers.h"
 #include "jitc.h"
 #include "jitc_asm.h"
 #include "jitc_debug.h"
@@ -1856,8 +1858,17 @@ void JITC::asmCALL(NativeAddress to)
 {
 	emitAssure(5);
 	byte instr[5];
+	sint64 disp = sint64(uintptr_t(to)) - sint64(uintptr_t(currentPage->tcp+5));
+	if (disp < -0x80000000LL || disp > 0x7fffffffLL) {
+		PPC_CPU_ERR("call rel32 out of range: target %p is %lld bytes from "
+			"the translation cache, beyond the +-2GB a signed 32-bit "
+			"displacement can encode. Native helpers must be reachable "
+			"from the translation cache; linking the executable non-PIE "
+			"(-no-pie) is the usual way to ensure this.\n",
+			to, (long long)disp);
+	}
 	instr[0] = 0xe8;
-	U32(instr + 1) = uint32(to - (currentPage->tcp+5));
+	U32(instr + 1) = uint32(disp);
 	emit(instr, 5);
 }
 

--- a/src/debug/Makefile.am
+++ b/src/debug/Makefile.am
@@ -11,3 +11,6 @@ debugparse.y debugtype.h lex.l lex.h parsehelper.c parsehelper.h debugger.cc deb
 stdfuncs.cc stdfuncs.h debugparse.h x86opc.cc x86opc.h x86dis.cc x86dis.h
 
 AM_CPPFLAGS = -I ..
+
+BUILT_SOURCES = debugparse.h
+lex.$(OBJEXT): debugparse.h

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -41,13 +41,13 @@ for cfg in "${TESTS[@]}"; do
 
     if [ ! -f "$elf" ]; then
         printf "%-24s SKIP (no .elf)\n" "$name"
-        ((skipped++))
+        skipped=$((skipped + 1))
         continue
     fi
 
     if output=$(timeout "$TIMEOUT" "$PPC" --headless "$cfg" 2>&1); then
         printf "%-24s PASS\n" "$name"
-        ((passed++))
+        passed=$((passed + 1))
     else
         rc=$?
         if [ $rc -eq 124 ]; then
@@ -57,7 +57,7 @@ for cfg in "${TESTS[@]}"; do
             echo "$output" | tail -5 | sed 's/^/  /'
         fi
         failures+=("$name")
-        ((failed++))
+        failed=$((failed + 1))
     fi
 done
 


### PR DESCRIPTION
While building PearPC on CachyOS, I ran into several build and test issues. This PR fixes an x86_64 JIT crash on toolchains that produce PIE executables by default, updates deprecated Autoconf usage, fixes a parallel-build race, and allows the headless test runner to complete under `set -e`.

Fixes:

- Link the x86_64 JIT as non-PIE to preserve its existing 32-bit address and `call rel32` assumptions
- Add runtime checks for out-of-range CPU-state and native-helper addresses
- Update deprecated Autoconf macros
- Suppress the duplicate `AC_PROG_LEX` deprecation warning
- Fix the parallel-build dependency on the generated `debugparse.h`
- Stop tracking Automake’s generated `compile` helper and add it to `.gitignore`
- Replace post-increment test counters with assignments that are safe under `set -e`

Verified on CachyOS x86_64: the build completes without Autoconf warnings, and the headless test runner reports 10 passing tests. The remaining AltiVec test failure is expected because the x86_64 JIT does not implement AltiVec.